### PR TITLE
Added settings to force a certain locale to be used.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -22,8 +22,12 @@ function activate(context) {
 
         editor.edit(function (editBuilder) {
             for(var i = 0; i < selections.length; i++){
+                var locale = vscode.workspace.getConfiguration('insertDateTime')['locale'];
                 var d = new Date;
-                var txt = d.toLocaleDateString() + " " + d.toLocaleTimeString();
+                if(locale != '')
+                    var txt = d.toLocaleString(locale);
+                else
+                    var txt = d.toLocaleString();
                 editBuilder.replace(selections[i], "");
                 editBuilder.insert(selections[i].active, txt);
             }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,17 @@
         "commands": [{
             "command": "extension.insertDateTime",
             "title": "Insert Date/Time"
-        }]
+        }],
+        "configuration": {
+            "title": "InsertDateTime Configuration",
+            "properties": {
+                "insertDateTime.locale":{
+                    "type": "string",
+                    "default": "",
+                    "description": "Sets the locale to be used. If undefined uses the system locale."
+                }
+            }
+        }
     },
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install"


### PR DESCRIPTION
Allows to set a different locale from the system locale.

Putting something like `"insertDateTime.locale": "de"` in the `settings.json` file will produce an output of `13.7.2016 14:12:10`. Can be freely changed to whatever locale vscode supports.
